### PR TITLE
Move part into Rcpp

### DIFF
--- a/SRR_profile.cpp
+++ b/SRR_profile.cpp
@@ -1,0 +1,90 @@
+# include <RcppArmadillo.h> 
+// [[Rcpp::depends(RcppArmadillo)]]
+using namespace Rcpp;
+using namespace arma;
+// [[Rcpp::export]]
+List SRR_profile_cpp(vec Y,vec Facility, mat z, vec sizev,double criterion,int max_iter,float bound) {
+  int N, nF;
+  N=Y.size();
+  vec Facility_list=unique(Facility);
+  nF=Facility_list.size();
+  vec gamma_est(nF);
+  gamma_est.fill(0);
+  int beta_length = z.n_cols;
+  vec beta_est(beta_length);
+  beta_est.fill(0);
+  int rep_n = 0;
+  vec llk_all(max_iter);
+  vec beta_update(beta_length);
+  beta_update.fill(1000);
+  vec Y_p(N);
+  vec gamma_update_pt1(nF);
+  vec gamma_update_pt2(nF);
+  vec gamma_update(nF);
+  vec beta_U(z.n_cols);
+  mat beta_I(z.n_cols,z.n_cols);
+  do{rep_n+=1;
+    cout<<rep_n<<endl;
+    vec gamma_est_long(N);
+    int start=0;
+    for(int f=0; f<nF; f++){
+      int end=start+sizev(f)-1;
+      gamma_est_long(span(start,end))=vec(sizev(f)).fill(gamma_est(f));
+      start=end+1;
+    }
+    vec exp_eta=exp(gamma_est_long+z*beta_est); 
+    vec p = exp_eta/(exp_eta+1); // / is element-wise division
+    double llk = sum(log(p));
+    llk_all(rep_n-1) = llk;
+    vec q = 1-p;
+    vec p_times_q = p%q;//%element-wise multiplication
+
+    vec gamma_update_pt1(nF);
+    gamma_update_pt1.fill(0);
+
+    gamma_update_pt2.fill(0);
+    Y_p=Y-p;
+    start=0;
+    for(int f=0; f<nF; f++){
+      int end=start+sizev(f)-1;
+      gamma_update_pt1[f]=sum(Y_p(span(start,end)));
+      gamma_update_pt2[f]=sum(p_times_q(span(start,end)));
+      start=end+1;
+    }
+    gamma_update=gamma_update_pt1/gamma_update_pt2;
+    gamma_est = gamma_est + gamma_update;
+    start=0;
+    for(int f=0; f<nF; f++){
+      int end=start+sizev(f)-1;
+      gamma_est_long(span(start,end))=vec(sizev(f)).fill(gamma_est(f));
+      start=end+1;
+    }
+    exp_eta=exp(gamma_est_long+z*beta_est);
+    p = exp_eta/(exp_eta+1);
+    p_times_q = p%q;
+    Y_p=Y-p;
+    vec beta_U = z.t()*Y_p;
+    mat z_pq(size(z));
+    for(unsigned int c=0;c<z.n_cols;c++){
+      z_pq.col(c)=z.col(c)%p_times_q;
+    }
+    mat beta_I = z.t()* z_pq;
+    beta_update = inv(beta_I)*beta_U;//inv() is to inverse a matrix
+    beta_est = beta_est +  beta_update;
+    uvec gamma_index1=find(gamma_est > bound);
+    uvec gamma_index2=find(gamma_est < -bound);
+    gamma_est.elem(gamma_index1) = vec(gamma_index1.size()).fill(bound);
+    gamma_est.elem(gamma_index2) = vec(gamma_index2.size()).fill(-bound);
+    uvec beta_index1=find(beta_est > bound);
+    uvec beta_index2=find(beta_est < -bound);
+    beta_est.elem(beta_index1) = vec(beta_index1.size()).fill(bound);
+    beta_est.elem(beta_index2) = vec(beta_index2.size()).fill(-bound);
+  } while (rep_n < (max_iter-1) && max(abs((beta_update))) > criterion);
+  llk_all.resize(rep_n);
+  List res;
+  res["beta.est"] = beta_est;
+  res["gamma.est"] = gamma_est;
+  res["llk_all"] = llk_all;
+  res["rep.n"] = rep_n-1;
+  return(res);
+}

--- a/test.R
+++ b/test.R
@@ -1,0 +1,36 @@
+rm(list=ls())
+library(RcppArmadillo)
+library(Rcpp)
+source('SRR_fixed_effect_lib.R')
+source('SRR_fixed_effect_lib_cpp.R')
+sourceCpp("SRR_profile.cpp")
+
+Y_name <- "Y"
+z_names <- c("z1","z2")
+
+N<-1000
+nF<-10
+size<-N/nF
+Fac_name <- "Facility" 
+Facility<-rep(1:nF,each=size)
+z1<-rnorm(N)
+z2<-rnorm(N)
+beta<-c(1,-1)
+gamma<-rnorm(nF)
+gamma_long<-rep(gamma, each=size)
+exp_eta<-exp(as.matrix(cbind(z1,z2))%*%beta+gamma_long)
+p<-exp_eta/(1+exp_eta)
+Y<-rbinom(N,size=1,prob=p)
+data=data.frame(Y,z1,z2,Facility)
+SRR_fixed_fit = SRR_fixed(data0 = data, Y_name, z_names, Fac_name, test = "Score", refer_fac = NULL,
+                          criterion = 1e-8, max.iter = 1000, bound = 8, size_cut = 10)
+SRR_fixed_fit_cpp = SRR_fixed_cpp(data0 = data, Y_name, z_names, Fac_name, test = "Score", refer_fac = NULL,
+                          criterion = 1e-8, max.iter = 1000, bound = 8, size_cut = 10)
+max(abs(SRR_fixed_fit_cpp$srr-SRR_fixed_fit$srr))
+max(abs(SRR_fixed_fit_cpp$beta-SRR_fixed_fit$beta))
+max(abs(SRR_fixed_fit_cpp$gamma-SRR_fixed_fit$gamma))
+max(abs(SRR_fixed_fit_cpp$iterN-SRR_fixed_fit$iterN))#sometimes can be not identical due to slightly different convergence
+max(abs(SRR_fixed_fit_cpp$Observed-SRR_fixed_fit$Observed))
+max(abs(SRR_fixed_fit_cpp$Expected-SRR_fixed_fit$Expected))
+identical(SRR_fixed_fit_cpp$Fnames,SRR_fixed_fit$Fnames)
+save.image("test.Rdata")


### PR DESCRIPTION
Instead of sourcing the function in SRR_fixed_Effec_lib.R, we move SRR_profile function into Rcpp, and renamed as SRR_profile_cpp. The updated function of SRR_fix_fit is called SRR_fixed_fit_cpp. Now, you need to source SRR_fixed_effect_lib_cpp.R and SRR_profile.cpp. The text.R is an example for you with simulated data and a comparison between the old SRR_fixed_Effec_lib.R and the new Rcpp version.